### PR TITLE
feat(ServiceLabor): add entity, repository, service, and REST controller

### DIFF
--- a/src/main/java/soat_fiap/siaes/domain/serviceLabor/model/ServiceLabor.java
+++ b/src/main/java/soat_fiap/siaes/domain/serviceLabor/model/ServiceLabor.java
@@ -1,0 +1,26 @@
+package soat_fiap.siaes.domain.serviceLabor.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Entity
+@Table(name = "tb_service_labor")
+public class ServiceLabor {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String description;   // (ex.: "Troca de óleo", "Alinhamento")
+
+    @Column(nullable = false)
+    private BigDecimal laborCost; // Custo da mão de obra
+}

--- a/src/main/java/soat_fiap/siaes/domain/serviceLabor/service/ServiceLaborService.java
+++ b/src/main/java/soat_fiap/siaes/domain/serviceLabor/service/ServiceLaborService.java
@@ -1,0 +1,82 @@
+package soat_fiap.siaes.domain.serviceLabor.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import soat_fiap.siaes.domain.serviceLabor.model.ServiceLabor;
+import soat_fiap.siaes.infrastructure.persistence.ServiceLabor.ServiceLaborRepository;
+import soat_fiap.siaes.interfaces.serviceLabor.dto.ServiceLaborRequest;
+import soat_fiap.siaes.interfaces.serviceLabor.dto.ServiceLaborResponse;
+
+import java.util.UUID;
+
+
+@Service
+@RequiredArgsConstructor
+public class ServiceLaborService {
+    private final ServiceLaborRepository repository;
+
+    public Page<ServiceLaborResponse> findAll(Pageable pageable) {
+        return repository.findAll(pageable)
+                .map(ServiceLaborResponse::new);
+    }
+
+    public ServiceLaborResponse findById(UUID id) {
+        return new ServiceLaborResponse(this.findByUUID(id));
+    }
+
+    @Transactional
+    public ServiceLaborResponse save(ServiceLaborRequest request) {
+        // Validação de duplicidade
+        if (repository.existsByDescription(request.description())) {
+            throw new IllegalArgumentException("Já existe um serviço com essa descrição.");
+        }
+
+        ServiceLabor labor = new ServiceLabor();
+        labor.setDescription(request.description());
+        labor.setLaborCost(request.laborCost());
+
+        return new ServiceLaborResponse(persist(labor));
+    }
+
+    @Transactional
+    private ServiceLabor persist(ServiceLabor labor) {
+        try {
+            return repository.save(labor);
+        }
+        catch (DataIntegrityViolationException e) {
+            throw new IllegalArgumentException("Erro ao salvar a mão de obra: dados inválidos ou violação de restrição no banco de dados.");
+        }
+        catch (JpaSystemException | PersistenceException e) {
+            throw new RuntimeException("Erro interno ao tentar persistir a mão de obra. Verifique a conexão com o banco ou a transação.");
+        }
+    }
+
+    @Transactional
+    public void deleteById(UUID id) {
+        repository.delete(this.findByUUID(id));
+    }
+
+    private ServiceLabor findByUUID(UUID id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Serviço com ID " + id + " não encontrado"));
+    }
+
+    public ServiceLaborResponse update(UUID id, ServiceLaborRequest request) {
+        ServiceLabor labor = this.findByUUID(id);
+
+        if (repository.existsByDescriptionAndIdNot(request.description(), id)) {
+            throw new IllegalArgumentException("Já existe um serviço com essa descrição.");
+        }
+        labor.setDescription(request.description());
+        labor.setLaborCost(request.laborCost());
+
+        return new ServiceLaborResponse(persist(labor));
+    }
+}

--- a/src/main/java/soat_fiap/siaes/infrastructure/config/CorsConfig.java
+++ b/src/main/java/soat_fiap/siaes/infrastructure/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package soat_fiap.siaes.config;
+package soat_fiap.siaes.infrastructure.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/soat_fiap/siaes/infrastructure/config/InitialSystemConfig.java
+++ b/src/main/java/soat_fiap/siaes/infrastructure/config/InitialSystemConfig.java
@@ -1,4 +1,4 @@
-package soat_fiap.siaes.config;
+package soat_fiap.siaes.infrastructure.config;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/soat_fiap/siaes/infrastructure/config/SecurityConfiguration.java
+++ b/src/main/java/soat_fiap/siaes/infrastructure/config/SecurityConfiguration.java
@@ -1,4 +1,4 @@
-package soat_fiap.siaes.config;
+package soat_fiap.siaes.infrastructure.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import soat_fiap.siaes.shared.AuthenticationService;
+import soat_fiap.siaes.interfaces.shared.AuthenticationService;
 import soat_fiap.siaes.domain.user.repository.UserRepository;
 
 @Configuration
@@ -41,10 +41,10 @@ public class SecurityConfiguration {
                         // Permissões granulares
                         .requestMatchers("/users/**").hasAnyRole("ADMIN", "COLLABORATOR")
                         .requestMatchers("/vehicles/**").hasAnyRole("ADMIN", "COLLABORATOR")
-                        .requestMatchers("/servicos/**").hasAnyRole("ADMIN", "COLLABORATOR")
-                        .requestMatchers("/pecas/**").hasRole("ADMIN") // só admin pode gerenciar estoque ou criar uma role para estoquista
-                        .requestMatchers("/ordens/**").hasAnyRole("ADMIN", "COLLABORATOR")
-                        .requestMatchers("/monitoramento/**").hasRole("ADMIN") // apenas admin vê métricas
+                        .requestMatchers("/service-labor/**").hasAnyRole("ADMIN", "COLLABORATOR")
+//                        .requestMatchers("/pecas/**").hasRole("ADMIN") // só admin pode gerenciar estoque ou criar uma role para estoquista
+//                        .requestMatchers("/ordens/**").hasAnyRole("ADMIN", "COLLABORATOR")
+//                        .requestMatchers("/monitoramento/**").hasRole("ADMIN") // apenas admin vê métricas
 
                         // Qualquer outra requisição requer autenticação
                         .anyRequest().authenticated()

--- a/src/main/java/soat_fiap/siaes/infrastructure/config/SecurityFilter.java
+++ b/src/main/java/soat_fiap/siaes/infrastructure/config/SecurityFilter.java
@@ -1,4 +1,4 @@
-package soat_fiap.siaes.config;
+package soat_fiap.siaes.infrastructure.config;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import soat_fiap.siaes.domain.user.model.User;
 import soat_fiap.siaes.domain.user.repository.UserRepository;
-import soat_fiap.siaes.shared.AuthenticationService;
+import soat_fiap.siaes.interfaces.shared.AuthenticationService;
 
 import java.io.IOException;
 

--- a/src/main/java/soat_fiap/siaes/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/soat_fiap/siaes/infrastructure/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package soat_fiap.siaes.config;
+package soat_fiap.siaes.infrastructure.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/soat_fiap/siaes/infrastructure/persistence/ServiceLabor/ServiceLaborRepository.java
+++ b/src/main/java/soat_fiap/siaes/infrastructure/persistence/ServiceLabor/ServiceLaborRepository.java
@@ -1,0 +1,16 @@
+package soat_fiap.siaes.infrastructure.persistence.ServiceLabor;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import soat_fiap.siaes.domain.serviceLabor.model.ServiceLabor;
+
+import java.util.UUID;
+
+@Repository
+public interface ServiceLaborRepository extends JpaRepository<ServiceLabor, UUID> {
+    // Verifica se já existe um registro com a descrição informada
+    boolean existsByDescription(String description);
+
+    // Verifica se já existe um registro com a descrição informada e ID diferente
+    boolean existsByDescriptionAndIdNot(String description, UUID id);
+}

--- a/src/main/java/soat_fiap/siaes/interfaces/serviceLabor/ServiceLaborController.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/serviceLabor/ServiceLaborController.java
@@ -1,0 +1,51 @@
+package soat_fiap.siaes.interfaces.serviceLabor;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import soat_fiap.siaes.domain.serviceLabor.service.ServiceLaborService;
+import soat_fiap.siaes.interfaces.serviceLabor.dto.ServiceLaborRequest;
+import soat_fiap.siaes.interfaces.serviceLabor.dto.ServiceLaborResponse;
+
+import java.util.UUID;
+
+
+@RestController
+@RequestMapping("/service-labor")
+@SecurityRequirement(name = "bearer-key")
+@RequiredArgsConstructor
+public class ServiceLaborController {
+    private final ServiceLaborService service;
+
+    @GetMapping
+    public ResponseEntity<Page<ServiceLaborResponse>> findAll(@ParameterObject Pageable pageable) {
+        return ResponseEntity.ok(service.findAll(pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ServiceLaborResponse> findById(@PathVariable UUID id) {
+        return ResponseEntity.ok(service.findById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<ServiceLaborResponse> save(@RequestBody @Valid ServiceLaborRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.save(request));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ServiceLaborResponse> update(@PathVariable UUID id, @RequestBody @Valid ServiceLaborRequest request) {
+        return ResponseEntity.ok(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteById(@PathVariable UUID id) {
+        service.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/soat_fiap/siaes/interfaces/serviceLabor/dto/ServiceLaborRequest.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/serviceLabor/dto/ServiceLaborRequest.java
@@ -1,0 +1,22 @@
+package soat_fiap.siaes.interfaces.serviceLabor.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+public record ServiceLaborRequest(
+
+        @NotBlank(message = "A descrição da mão de obra é obrigatória.")
+        @Size(min = 3, max = 100, message = "A descrição deve ter entre 3 e 100 caracteres.")
+        String description,
+
+        @NotNull(message = "O custo da mão de obra é obrigatório.")
+        @DecimalMin(value = "0.0", inclusive = false, message = "O custo da mão de obra deve ser maior que zero.")
+        @Digits(integer = 10, fraction = 2, message = "O custo da mão de obra deve ter no máximo 10 dígitos inteiros e 2 decimais.")
+        BigDecimal laborCost
+) {
+}

--- a/src/main/java/soat_fiap/siaes/interfaces/serviceLabor/dto/ServiceLaborResponse.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/serviceLabor/dto/ServiceLaborResponse.java
@@ -1,0 +1,19 @@
+package soat_fiap.siaes.interfaces.serviceLabor.dto;
+
+import soat_fiap.siaes.domain.serviceLabor.model.ServiceLabor;
+
+import java.math.BigDecimal;
+
+public record ServiceLaborResponse(
+        String id,
+        String description,
+        BigDecimal laborCost
+) {
+    public ServiceLaborResponse(ServiceLabor labor) {
+        this(
+                labor.getId().toString(),
+                labor.getDescription(),
+                labor.getLaborCost()
+        );
+    }
+}

--- a/src/main/java/soat_fiap/siaes/interfaces/shared/AuthenticationService.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/shared/AuthenticationService.java
@@ -1,4 +1,4 @@
-package soat_fiap.siaes.shared;
+package soat_fiap.siaes.interfaces.shared;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;

--- a/src/main/java/soat_fiap/siaes/interfaces/shared/Document.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/shared/Document.java
@@ -1,4 +1,4 @@
-package soat_fiap.siaes.shared;
+package soat_fiap.siaes.interfaces.shared;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;

--- a/src/main/java/soat_fiap/siaes/interfaces/shared/GlobalExceptionHandler.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/shared/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package soat_fiap.siaes.shared;
+package soat_fiap.siaes.interfaces.shared;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/soat_fiap/siaes/interfaces/shared/constraint/BrazilianLicensePlateValidator.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/shared/constraint/BrazilianLicensePlateValidator.java
@@ -1,8 +1,8 @@
-package soat_fiap.siaes.shared.constraint;
+package soat_fiap.siaes.interfaces.shared.constraint;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import soat_fiap.siaes.shared.validation.BrazilianLicensePlate;
+import soat_fiap.siaes.interfaces.shared.validation.BrazilianLicensePlate;
 
 /**
  * Validator for Brazilian vehicle license plates.

--- a/src/main/java/soat_fiap/siaes/interfaces/shared/validation/BrazilianLicensePlate.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/shared/validation/BrazilianLicensePlate.java
@@ -1,8 +1,8 @@
-package soat_fiap.siaes.shared.validation;
+package soat_fiap.siaes.interfaces.shared.validation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-import soat_fiap.siaes.shared.constraint.BrazilianLicensePlateValidator;
+import soat_fiap.siaes.interfaces.shared.constraint.BrazilianLicensePlateValidator;
 
 import java.lang.annotation.*;
 

--- a/src/main/java/soat_fiap/siaes/interfaces/user/AuthenticationController.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/user/AuthenticationController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 import soat_fiap.siaes.interfaces.user.dto.LoginRequest;
-import soat_fiap.siaes.shared.AuthenticationService;
+import soat_fiap.siaes.interfaces.shared.AuthenticationService;
 
 @RestController
 @RequestMapping("/auth")

--- a/src/main/java/soat_fiap/siaes/interfaces/user/dto/CreateUserRequest.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/user/dto/CreateUserRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import soat_fiap.siaes.domain.user.model.RoleEnum;
 import soat_fiap.siaes.domain.user.model.User;
-import soat_fiap.siaes.shared.Document;
+import soat_fiap.siaes.interfaces.shared.Document;
 
 public record CreateUserRequest(
         @NotBlank String name,

--- a/src/main/java/soat_fiap/siaes/interfaces/vehicle/dto/CreateVehicleRequest.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/vehicle/dto/CreateVehicleRequest.java
@@ -3,7 +3,7 @@ package soat_fiap.siaes.interfaces.vehicle.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import soat_fiap.siaes.domain.vehicle.model.Vehicle;
-import soat_fiap.siaes.shared.validation.BrazilianLicensePlate;
+import soat_fiap.siaes.interfaces.shared.validation.BrazilianLicensePlate;
 
 public record CreateVehicleRequest(
         @NotBlank(message = "A placa é obrigatória")

--- a/src/main/java/soat_fiap/siaes/interfaces/vehicle/dto/UpdateVehicleRequest.java
+++ b/src/main/java/soat_fiap/siaes/interfaces/vehicle/dto/UpdateVehicleRequest.java
@@ -2,7 +2,7 @@ package soat_fiap.siaes.interfaces.vehicle.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import soat_fiap.siaes.shared.validation.BrazilianLicensePlate;
+import soat_fiap.siaes.interfaces.shared.validation.BrazilianLicensePlate;
 
 public record UpdateVehicleRequest(
         @NotBlank(message = "A placa é obrigatória")


### PR DESCRIPTION
This PR introduces the ServiceLabor module to the application, including:

- ServiceLabor entity: represents labor/service with description and cost.
- ServiceLaborRepository: JpaRepository for CRUD operations.
- ServiceLaborService: handles business logic, including validation for duplicate descriptions.
- ServiceLaborController: exposes REST endpoints for listing, retrieving, and creating ServiceLabor records.

Additional features:
- Validation for required fields and unique description.
- Exception handling with meaningful messages in Portuguese.
- Pagination support for listing all ServiceLabor records.

This implementation lays the foundation for managing labor/services in the system and ensures data integrity and proper error handling.
